### PR TITLE
Add type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,14 +2,22 @@
   "name": "create-jest-runner",
   "version": "0.7.0",
   "main": "build/index.js",
+  "types": "types/index.d.ts",
   "author": "Rogelio Guzman <rogelioguzmanh@gmail.com>",
+  "contributors": [
+    {
+      "name": "Lok Shun Hung",
+      "url": "https://github.com/lokshunhung"
+    }
+  ],
   "description": "A simple way of creating a Jest runner",
   "license": "MIT",
   "repository": "https://github.com/jest-community/create-jest-runner.git",
   "homepage": "https://github.com/jest-community/create-jest-runner",
   "files": [
     "build/",
-    "generator/"
+    "generator/",
+    "types/"
   ],
   "scripts": {
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "types/"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "jest --no-color",
     "lint": "eslint .",
     "prettier:run": "prettier '*.md' '.github/**' '*.json' '**/package.json' '.vscode/*.json' 'generator/fixtures/*'",
     "prettier:check": "yarn prettier:run --check",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,59 @@
+import { TestResult } from '@jest/test-result';
+import * as TestRunner from 'jest-runner';
+
+type Milliseconds = number;
+
+interface TestObj extends Record<string, any> {
+  path: string;
+  title?: string;
+  duration?: Milliseconds;
+}
+
+export function createJestRunner(
+  pathToRunFile: string,
+  config: { getExtraOptions: () => object },
+): TestRunner;
+
+export function fail(options: {
+  start: number;
+  end: number;
+  test: TestObj;
+  errorMessage?: string;
+}): TestResult;
+
+export function pass(options: {
+  start: number;
+  end: number;
+  test: TestObj;
+}): TestResult;
+
+export function skip(options: {
+  start: number;
+  end: number;
+  test: TestObj;
+}): TestResult;
+
+export function todo(options: {
+  start: number;
+  end: number;
+  test: TestObj;
+}): TestResult;
+
+export function toTestResult(options: {
+  stats: {
+    failures: number;
+    passes: number;
+    pending: number;
+    todo: number;
+    end: number;
+    start: number;
+  };
+  skipped: boolean;
+  errorMessage?: string | null;
+  tests: Array<{
+    duration?: Milliseconds | null;
+    errorMessage?: string;
+    testPath?: string;
+    title?: string;
+  }>;
+}): TestResult;


### PR DESCRIPTION
This pr adds type definitions and addresses #36

The type definitions are made from reading the source code.
Please let me know if they are inaccurate.

I also add the `--no-color` flag when running jest since snapshots failed when I run them with iTerm2 on MacOSX.
