### PR TITLE
failureMessages contain [undefined] on pass

### DIFF
--- a/lib/toTestResult.js
+++ b/lib/toTestResult.js
@@ -32,7 +32,7 @@ const toTestResult = ({
       return {
         ancestorTitles: [],
         duration: test.duration,
-        failureMessages: [test.errorMessage],
+        failureMessages: test.errorMessage ? [test.errorMessage] : [],
         fullName: test.testPath,
         numPassingAsserts: test.errorMessage ? 1 : 0,
         status: test.errorMessage ? 'failed' : 'passed',


### PR DESCRIPTION
In combination with eg. jest-runner-eslint or jest-runner-sasslint, passing tests are shown as having errors.

```
    {
      "title": "ESLint (30)",
      "fullTitle": <path>/usePrevious_ts",
      "duration": 24,
      "errorCount": 1,
      "error": "1 failure:\n* undefined"
    }
```
This is because the failureMessages becomes [undefined]