### PR TITLE
refactor: remove unnecessary ProcessTerminatedError logic

### DIFF
--- a/lib/createJestRunner.ts
+++ b/lib/createJestRunner.ts
@@ -136,22 +136,6 @@ export default function createRunner<
           });
         });
 
-      const onError = (
-        err: JestResult.SerializableError,
-        test: JestRunner.Test,
-      ) => {
-        return onFailure(test, err).then(() => {
-          if (err.type === 'ProcessTerminatedError') {
-            // eslint-disable-next-line no-console
-            console.error(
-              'A worker process has quit unexpectedly! ' +
-                'Most likely this is an initialization error.',
-            );
-            process.exit(1);
-          }
-        });
-      };
-
       const onInterrupt = new Promise((_, reject) => {
         watcher.on('change', state => {
           if (state.interrupted) {
@@ -164,7 +148,7 @@ export default function createRunner<
         tests.map(test =>
           runTestInWorker(test)
             .then(testResult => onResult(test, testResult))
-            .catch(error => onError(error, test)),
+            .catch(error => onFailure(test, error)),
         ),
       );
 

--- a/lib/createJestRunner.ts
+++ b/lib/createJestRunner.ts
@@ -1,4 +1,3 @@
-import type * as JestResult from '@jest/test-result';
 import type { Config } from '@jest/types';
 import type * as JestRunner from 'jest-runner';
 import { Worker } from 'jest-worker';


### PR DESCRIPTION
Following up https://github.com/facebook/jest/pull/12287

`worker-farm` library is not used in this project. Hence logic which handles `ProcessTerminatedError` is redundant here too.