### PR TITLE
chore: use ESLint `consistent-type-imports` rule instead of TypeScript’s `importsNotUsedAsValues`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,10 @@
     "max-classes-per-file": "off",
     "no-underscore-dangle": "off",
     "no-useless-constructor": "off",
+    "@typescript-eslint/consistent-type-imports": [
+      "error",
+      { "fixStyle": "inline-type-imports" }
+    ],
     "@typescript-eslint/prefer-ts-expect-error": "error"
   },
   "env": {

--- a/lib/createJestRunner.ts
+++ b/lib/createJestRunner.ts
@@ -9,7 +9,7 @@ import type {
   TestRunnerOptions,
   TestWatcher,
 } from 'jest-runner';
-import { Worker, JestWorkerFarm } from 'jest-worker';
+import { Worker, type JestWorkerFarm } from 'jest-worker';
 import pLimit from 'p-limit';
 import type { CreateRunnerOptions, RunTestOptions } from './types';
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
     "outDir": "./build/",
     "noErrorTruncation": true,
     "isolatedModules": true,
-    "importsNotUsedAsValues": "error",
 
     "stripInternal": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Unblocks #198

The `importsNotUsedAsValues` has been deprecated in TypeScript 5. Perhaps it is good idea to use ESLint’s [`consistent-type-imports`](https://typescript-eslint.io/rules/consistent-type-imports/) rule instead?

If this is acceptable, I could do the same in Jest repo as well.